### PR TITLE
Support targets without any attributes yet.

### DIFF
--- a/lib/xcprovisioner/runner.rb
+++ b/lib/xcprovisioner/runner.rb
@@ -90,6 +90,7 @@ module XCProvisioner
     def switch_to_manual_signing(target)
       target_id = target.uuid
       attributes = project.root_object.attributes['TargetAttributes']
+      attributes[target_id] ||= {}
       target_attributes = attributes[target_id]
       target_attributes['ProvisioningStyle'] = 'Manual'
     end


### PR DESCRIPTION
Our XcodeGen generated project does not necessarily specify `TargetAttributes` for every target.