### PR TITLE
Remove activesupport dependency

### DIFF
--- a/xcprovisioner.gemspec
+++ b/xcprovisioner.gemspec
@@ -33,8 +33,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'xcodeproj', '~> 1.4'
 
-  spec.add_runtime_dependency 'activesupport', '>= 3', '< 5.0'
-
   spec.add_development_dependency 'bundler', '~> 1.13'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
I don't claim to know Ruby/Gems very well, but as best I can tell, this dependency isn't actually used. Certainly let me know if i'm mistaken. 

Seems to pass tests via `rake spec`.  Additionally i've used it locally and it seems to work as expected. 